### PR TITLE
Specify action version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For example use this at the end of your job like this:
 ```
 - name: update deploy status
     if: always()
-    uses: unacast/actions-github-deployment-status@master
+    uses: unacast/actions-github-deployment-status@0.2
     with:
       github_token: ${{ secrets.GITHUB_TOKEN }}
       status: ${{ job.status }}


### PR DESCRIPTION
As a best practice we should pin the action version in the README to avoid users getting incompatible upgrades in the future. 