### PR TITLE
Add an `env.` in front of DEPLOY_ENVIRONMENT

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           status: ${{ job.status }}
           description: "Deployed to some magic"
-          environment_url: '${{ DEPLOY_ENVIRONMENT }}'
+          environment_url: '${{ env.DEPLOY_ENVIRONMENT }}'
 ```
 
 ### Inputs


### PR DESCRIPTION
I'm pretty sure that it has to be `environment_url: '${{ env.DEPLOY_ENVIRONMENT }}' or have you tested it with just `environment_url: '${{ DEPLOY_ENVIRONMENT }}'` @judoole ?